### PR TITLE
Init gitmodule fonts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,6 @@ tmp
 # Artifacts of core work
 core
 documentserver-snap
+reports
 report.txt
+documents

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "assets/fonts"]
+	path = assets/fonts
+	url = git@github.com:ONLYOFFICE-QA/onlyoffice_private_fonts.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "assets/fonts"]
 	path = assets/fonts
-	url = git@github.com:ONLYOFFICE-QA/onlyoffice_private_fonts.git
+	url = https://github.com/ONLYOFFICE-QA/onlyoffice_private_fonts.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "assets/fonts"]
 	path = assets/fonts
 	url = git@github.com:ONLYOFFICE-QA/onlyoffice_private_fonts.git
+	branch = master/en

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "assets/fonts"]
 	path = assets/fonts
-	url = https://github.com/ONLYOFFICE-QA/onlyoffice_private_fonts.git
+	url = git@github.com:ONLYOFFICE-QA/onlyoffice_private_fonts.git

--- a/assets/x2ttester_configs/all.xml
+++ b/assets/x2ttester_configs/all.xml
@@ -6,6 +6,6 @@
 	<x2tPath>./x2t.exe</x2tPath>
 	<cores>4</cores>
 	<fonts system="0">
-		<directory>../fonts</directory>
+		<directory>../assets/fonts</directory>
 	</fonts>
 </settings>

--- a/assets/x2ttester_configs/documents.xml
+++ b/assets/x2ttester_configs/documents.xml
@@ -7,6 +7,6 @@
 	<cores>4</cores>
 	<input>documents</input>
 	<fonts system="0">
-		<directory>../fonts</directory>
+		<directory>../assets/fonts</directory>
 	</fonts>
 </settings>

--- a/assets/x2ttester_configs/presentations.xml
+++ b/assets/x2ttester_configs/presentations.xml
@@ -7,6 +7,6 @@
 	<cores>4</cores>
 	<input>presentations</input>
 	<fonts system="0">
-		<directory>../fonts</directory>
+		<directory>../assets/fonts</directory>
 	</fonts>
 </settings>

--- a/assets/x2ttester_configs/spreadsheets.xml
+++ b/assets/x2ttester_configs/spreadsheets.xml
@@ -7,6 +7,6 @@
 	<cores>4</cores>
 	<input>spreadsheets</input>
 	<fonts system="0">
-		<directory>../fonts</directory>
+		<directory>../assets/fonts</directory>
 	</fonts>
 </settings>

--- a/readme.md
+++ b/readme.md
@@ -8,13 +8,22 @@ For local startup in developer mode,
 recommended installing a local `bundle config` file.
 
 ```shell
-bundle config set --local with development
+  bundle config set --local with development
 ```
 
 Afterwards install the dependencies with the bundle.
 
 ```shell
-bundle install
+  bundle install
+```
+
+### Private fonts as a submodule
+
+The x2ttester run uses fonts from a private repository.
+You can install them as a `member` of ONLYOFFICE-QA and must have `ssh` access to the repository set up.
+
+```shell
+  git submodule update --init --recursive
 ```
 
 ## Key Features


### PR DESCRIPTION
The x2ttester run uses fonts from a private repository. You can install them as a member of ONLYOFFICE-QA and must have ssh access to the repository set up.